### PR TITLE
Enable deprecated authconfig only with rhel version < 9

### DIFF
--- a/Library/ldap/main.fmf
+++ b/Library/ldap/main.fmf
@@ -3,11 +3,14 @@ summary: Basic library for manipulation with sudoers entries in ldap via sudo-ld
 contact:
 - David Spurek <dspurek@redhat.com>
 require:
-- name: /Library/basic
-  url: https://pkgs.devel.redhat.com/git/tests/authconfig
-  type: library
-- library(distribution/authconf)
 - sudo
+adjust:
+  - require+:
+    - name: /Library/basic
+      url: https://pkgs.devel.redhat.com/git/tests/authconfig
+      type: library
+    - library(distribution/authconf)
+    when: distro < rhel-9
 provide:
   - library(sudo/ldap)
 duration: 5m

--- a/Library/ldap/main.fmf
+++ b/Library/ldap/main.fmf
@@ -4,11 +4,11 @@ contact:
 - David Spurek <dspurek@redhat.com>
 require:
 - sudo
+- name: /Library/basic
+  url: https://pkgs.devel.redhat.com/git/tests/authconfig
+  type: library
 adjust:
   - require+:
-    - name: /Library/basic
-      url: https://pkgs.devel.redhat.com/git/tests/authconfig
-      type: library
     - library(distribution/authconf)
     when: distro < rhel-9
 provide:


### PR DESCRIPTION
authconfig library is deprecated on rhel-9 and rhel-10. This PR modifies main.fmf file of the library and adjusting usage of this library only with a rhel version lower that 9.