### PR TITLE
Added ImageMode tag to tests

### DIFF
--- a/Sanity/Timestamp-files/main.fmf
+++ b/Sanity/Timestamp-files/main.fmf
@@ -13,6 +13,7 @@ tag:
 - TIPpass_Security
 - Tier1
 - Tier1security
+- ImageMode
 tier: '1'
 extra-summary: ' /CoreOS/sudo/Sanity/Timestamp-files'
 extra-task: /CoreOS/sudo/Sanity/Timestamp-files

--- a/Sanity/default-sudo-config-files/main.fmf
+++ b/Sanity/default-sudo-config-files/main.fmf
@@ -25,6 +25,7 @@ tag:
 - TierCandidatesPASS
 - rhel-6.8
 - rhel-7.2
+- ImageMode
 tier: '1'
 extra-summary: /CoreOS/sudo/Sanity/default-sudo-config-files
 extra-task: /CoreOS/sudo/Sanity/default-sudo-config-files


### PR DESCRIPTION
I added ImageMode tag to /Sanity/Timestamp-files and /Sanity/default-sudo-config-files tests, both passed tests in imagemode.
https://artifacts.osci.redhat.com/testing-farm/0a3ba2f3-617c-4b8c-b7ca-31338cb5d860/