### PR TITLE
Add missing Makefiles for Library/common and CVE-2025-32463-LPE-via-chroot-option 

### DIFF
--- a/Library/common/Makefile
+++ b/Library/common/Makefile
@@ -1,0 +1,57 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Makefile of /CoreOS/sudo/Library/common
+#   Description: A library for manipulation with sudoers entries locally and in ldap via sudo-ldap or sssd.
+#   Author: Dalibor Pospisil <dapospis@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2017 Red Hat, Inc.
+#
+#   This program is free software: you can redistribute it and/or
+#   modify it under the terms of the GNU General Public License as
+#   published by the Free Software Foundation, either version 2 of
+#   the License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE.  See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program. If not, see http://www.gnu.org/licenses/.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+export TEST=/CoreOS/sudo/Library/common
+export TESTVERSION=1.0
+
+BUILT_FILES=
+
+FILES=$(METADATA) Makefile lib.sh
+
+.PHONY: all install download clean
+
+clean:
+	rm -f *~ $(BUILT_FILES)
+
+
+include /usr/share/rhts/lib/rhts-make.include
+
+$(METADATA): Makefile
+	@echo "Owner:           Dalibor Pospisil <dapospis@redhat.com>" > $(METADATA)
+	@echo "Name:            $(TEST)" >> $(METADATA)
+	@echo "TestVersion:     $(TESTVERSION)" >> $(METADATA)
+	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
+	@echo "Description:     A library for manipulation with sudoers entries locally and in ldap via sudo-ldap or sssd." >> $(METADATA)
+	@echo "Type:            Library" >> $(METADATA)
+	@echo "TestTime:        5m" >> $(METADATA)
+	@echo "RunFor:          $(COMPONENT)" >> $(METADATA)
+	@echo "RhtsRequires:    sudo" >> $(METADATA)
+	@echo "Provides:        library(sudo/common)" >> $(METADATA)
+	@echo "Priority:        Normal" >> $(METADATA)
+	@echo "License:         GPLv2+" >> $(METADATA)
+	@echo "Confidential:    no" >> $(METADATA)
+	@echo "Destructive:     no" >> $(METADATA)
+
+	rhts-lint $(METADATA)

--- a/Regression/CVE-2025-32463-LPE-via-chroot-option/Makefile
+++ b/Regression/CVE-2025-32463-LPE-via-chroot-option/Makefile
@@ -1,4 +1,4 @@
-TESTBASE=/Regression/bz1972820-use_pty-with-SELinux-ROLE
+TESTBASE=/Regression/CVE-2025-32463-LPE-via-chroot-option
 export TEST=$(TESTBASE)$(if $(RELEASE),,/$(USER))
 export TESTVERSION=$(shell echo -n `date +%Y%m%d%H%M%S`; \
         [ -n "`git status --porcelain --untracked-files=no`" ] && \
@@ -10,12 +10,10 @@ Name:            $(TEST)
 TestVersion:     $(TESTVERSION)
 Path:            $(TESTBASE)
 Priority:        Normal
+Requires:        sudo strace
 License:         GPLv2+
 Confidential:    no
 Destructive:     no
-RhtsRequires:    library(sudo/common)
-Requires:        sudo
-Requires:        expect
 endef
 export TESTMETA
 

--- a/Regression/CVE-2025-32463-LPE-via-chroot-option/main.fmf
+++ b/Regression/CVE-2025-32463-LPE-via-chroot-option/main.fmf
@@ -2,6 +2,9 @@ description: 'Verify that an attacker cannot leverage sudo R (-chroot)
     option to run arbitrary commands as root, even if they are not listed in the sudoers file.'
 contact: Patrik Koncity <pkoncity@redhat.com>
 test: ./runtest.sh
+require:
+- sudo
+- strace
 duration: 5m
 enabled: true
 tag:

--- a/Regression/CVE-2025-32463-LPE-via-chroot-option/runtest.sh
+++ b/Regression/CVE-2025-32463-LPE-via-chroot-option/runtest.sh
@@ -30,7 +30,6 @@
 rlJournalStart
     rlPhaseStartSetup
         rlRun "rlImport --all" 0 "Import libraries"
-        rlRun "rlCheckRecommended"
         rlRun "rlCheckRequired"
         # Create a temporary user and home directory
         testUser=$(mktemp -u test-XXXX)

--- a/Regression/bz1664147-sudo-modifies-command-output-showing-Last-login/runtest.sh
+++ b/Regression/bz1664147-sudo-modifies-command-output-showing-Last-login/runtest.sh
@@ -29,6 +29,7 @@
 # Include Beaker environment
 . /usr/bin/rhts-environment.sh || :
 . /usr/share/beakerlib/beakerlib.sh || exit 1
+. /mnt/tests/CoreOS/sudo/Library/common/lib.sh || :
 
 PACKAGE="sudo"
 

--- a/Regression/bz1788196-sudo-allows-privilege-escalation-with-expire/runtest.sh
+++ b/Regression/bz1788196-sudo-allows-privilege-escalation-with-expire/runtest.sh
@@ -29,6 +29,7 @@
 # Include Beaker environment
 . /usr/bin/rhts-environment.sh || :
 . /usr/share/beakerlib/beakerlib.sh || exit 1
+. /mnt/tests/CoreOS/sudo/Library/common/lib.sh || :
 
 PACKAGE="sudo"
 

--- a/Regression/bz1972820-use_pty-with-SELinux-ROLE/runtest.sh
+++ b/Regression/bz1972820-use_pty-with-SELinux-ROLE/runtest.sh
@@ -29,6 +29,7 @@
 # Include rhts environment
 . /usr/bin/rhts-environment.sh || :
 . /usr/share/beakerlib/beakerlib.sh || exit 1
+. /mnt/tests/CoreOS/sudo/Library/common/lib.sh || :
 
 rlJournalStart && {
   rlPhaseStartSetup && {


### PR DESCRIPTION
Add missing Makefiles for Library/common and CVE-2025-32463-LPE-via-chroot-option 

Tweak:  bz1664147-sudo-modifies-command-output-showing-Last-login, bz1788196-sudo-allows-privilege-escalation-with-expire, bz1972820-use_pty-with-SELinux-ROLE  to properly include sudo/common.