### PR TITLE
Fix flake8 issues in static analysis

### DIFF
--- a/pytest/tests/test_basic.py
+++ b/pytest/tests/test_basic.py
@@ -192,7 +192,7 @@ def test_basic__single_group_by_gid(client: Client, provider: GenericProvider):
     _setup_sudo(client, provider)
     u = provider.user("user-1").add()
     u_deny = provider.user("user-deny").add()
-    g = provider.group("group-1").add(gid=20001).add_member(u)
+    provider.group("group-1").add(gid=20001).add_member(u)
     provider.sudorule("test").add(user="%#20001", host="ALL", command="/bin/ls")
     client.sssd.restart()
 
@@ -364,7 +364,7 @@ def test_basic__single_netgroup(client: Client, provider: GenericProvider):
     _setup_sudo(client, provider)
     u = provider.user("user-1").add()
     u_deny = provider.user("user-deny").add()
-    ng = provider.netgroup("ng-1").add().add_member(user=u)
+    provider.netgroup("ng-1").add().add_member(user=u)
     provider.sudorule("test").add(user="+ng-1", host="ALL", command="/bin/ls")
     client.sssd.restart()
 
@@ -726,7 +726,7 @@ def test_basic__single_runasgroup_by_gid(client: Client, provider: GenericProvid
 @pytest.mark.importance("critical")
 @pytest.mark.contains_workaround_for(gh=4483)
 @pytest.mark.topology(KnownTopology.BareClient)
-def test_basic__multiple_runasgroup(client: Cliewnt, provider: GenericProvider):
+def test_basic__multiple_runasgroup(client: Client, provider: GenericProvider):
     """
     :title: Command can be run as another group from list
     :setup:

--- a/pytest/tests/test_sudo.py
+++ b/pytest/tests/test_sudo.py
@@ -11,7 +11,7 @@ import time
 from datetime import datetime, timedelta
 
 from sssd_test_framework.roles.client import Client
-from sssd_test_framework.roles.generic import GenericADProvider, GenericProvider
+from sssd_test_framework.roles.generic import GenericProvider
 from sssd_test_framework.roles.ldap import LDAP
 from sssd_test_framework.topology import KnownTopology
 


### PR DESCRIPTION
## Summary by Sourcery

Resolve linting and typing issues in sudo-related pytest tests.

Bug Fixes:
- Remove unused variables in sudo basic tests to satisfy static analysis.
- Correct a misspelled test function parameter type in sudo runasgroup test to match the Client fixture.

Tests:
- Clean up sudo-related pytest tests to comply with flake8 and type checking.