### PR TITLE
Add ci for pytest on centos-10 and centos-9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
       matrix:
         tag:
         - fedora-latest
+        - centos-10
+        - centos-9
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -23,7 +25,7 @@ jobs:
         python-version: 3.x
 
     - name: Checkout sssd-test-framework repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         # Fetch the entire history of the repository and tags to determine
         # correct framework version, as it is constructed from git describe
@@ -33,7 +35,7 @@ jobs:
         path: sssd-test-framework
 
     - name: Checkout sudo-tests repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         repository: RedHat-SP-Security/sudo-tests
         path: sudo-tests
@@ -44,7 +46,8 @@ jobs:
         path: sssd-ci-containers
         registry: quay.io/sssd
         tag: ${{ matrix.tag }}
-        limit: "client ipa ldap"
+        # ci-dns (dnsmasq) must be in the stack or *.test hostnames used by pytest-mh will not resolve.
+        limit: "dns client ipa ldap"
 
     - name: Patch the SSH configuration
       uses: SSSD/sssd-ci-containers/actions/exec@master
@@ -52,10 +55,13 @@ jobs:
         user: root
         script: |
           #!/bin/bash
-          test -x /usr/bin/sss_ssh_knownhosts && \
-              sed -e 's/GlobalKnownHostsFile/#GlobalKnownHostsFile/' \
-                  -e 's/ProxyCommand \/usr\/bin\/sss_ssh_knownhostsproxy -p %p %h/KnownHostsCommand \/usr\/bin\/sss_ssh_knownhosts %H/' \
-                  -i /etc/ssh/ssh_config.d/04-ipa.conf
+          set -e
+          IPA_SSH=/etc/ssh/ssh_config.d/04-ipa.conf
+          if [ -x /usr/bin/sss_ssh_knownhosts ] && [ -f "$IPA_SSH" ]; then
+            sed -e 's/GlobalKnownHostsFile/#GlobalKnownHostsFile/' \
+                -e 's/ProxyCommand \/usr\/bin\/sss_ssh_knownhostsproxy -p %p %h/KnownHostsCommand \/usr\/bin\/sss_ssh_knownhosts %H/' \
+                -i "$IPA_SSH"
+          fi
 
     - name: Install system tests dependencies
       shell: bash
@@ -111,6 +117,25 @@ jobs:
           --output-polarion-testcase=$GITHUB_WORKSPACE/artifacts/testcase.xml \
           --collect-only . |& tee $GITHUB_WORKSPACE/pytest-collect.log
 
+    - name: Add extra packages needed for sudo tests on CentOS 9
+      uses: SSSD/sssd-ci-containers/actions/exec@master
+      with:
+        user: root
+        script: |
+          #!/bin/bash
+          set -e
+          dnf install -y sudo shadow-utils passwd zsh
+
+    - name: Show sudo version on client
+      uses: SSSD/sssd-ci-containers/actions/exec@master
+      with:
+        user: root
+        where: client
+        script: |
+          #!/bin/bash
+          set -eux
+          sudo --version
+
     - name: Run tests
       shell: bash
       working-directory: ./sudo-tests/pytest/
@@ -132,7 +157,7 @@ jobs:
 
     - name: Upload artifacts
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         if-no-files-found: ignore
         name: ${{ matrix.tag }}-system


### PR DESCRIPTION
Add additional ci and update github action versions.

## Summary by Sourcery

Extend CI coverage to additional CentOS images and update GitHub Actions versions in the main test workflow.

CI:
- Run the pytest workflow against new centos-10 and centos-9 container tags.
- Bump actions/checkout to v6 in repository checkout steps within the CI workflow.
- Upgrade actions/upload-artifact to v7 for artifact handling in CI runs.