### PR TITLE
Hostname ipa

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,6 @@ jobs:
     - name: Checkout sudo-tests repository
       uses: actions/checkout@v6
       with:
-        repository: RedHat-SP-Security/sudo-tests
         path: sudo-tests
 
     - name: Setup containers

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -23,7 +23,6 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v5
       with:
-        repository: RedHat-SP-Security/sudo-tests
         path: sudo-tests
 
     - name: Setup virtual environment

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,61 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Virtual environments
+.venv/
+venv/
+ENV/
+env/
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage
+.pytest_cache/
+.coverage
+.coverage.*
+htmlcov/
+.tox/
+.nox/
+coverage.xml
+*.cover
+.hypothesis/
+
+# Type checkers / linters
+.mypy_cache/
+.dmypy.json
+dmypy.json
+.ruff_cache/
+
+# pyenv
+.python-version
+
+# Environments
+.env
+.envrc

--- a/pytest/tests/test_basic.py
+++ b/pytest/tests/test_basic.py
@@ -828,17 +828,19 @@ def test_basic__hostname_hostname(client: Client, provider: GenericProvider, nam
     u = provider.user("user-1").add()
     other_host = "other"
 
-    if name == "shortname":
-        allowed_host = client.host.hostname.split(".")[0]
-    elif name == "fqdn":
-        allowed_host = client.host.hostname
-        other_host = "other.test"
-    elif name == "wildcard_shortname":
-        allowed_host = f"*{client.host.hostname.split(".")[0][2:]}"
-    elif name == "wildcard_fqdn":
-        allowed_host = f"*{client.host.hostname[2:]}"
-    else:
-        raise ValueError(f"Invalid hostname type: {name}")
+    match name:
+        case "shortname":
+            allowed_host = client.hostnameutils.shortname
+        case "fqdn":
+            fqdn = client.hostnameutils.fqdn
+            allowed_host = fqdn
+            other_host = f"other.{fqdn.split('.', 1)[1]}" if "." in fqdn else "other"
+        case "wildcard_shortname":
+            allowed_host = f"*{client.hostnameutils.shortname[2:]}"
+        case "wildcard_fqdn":
+            allowed_host = f"*{client.hostnameutils.fqdn[2:]}"
+        case _:
+            raise ValueError(f"Invalid hostname type: {name}")
 
     provider.sudorule("test1").add(user=u, host=allowed_host, command="/bin/ls")
     provider.sudorule("test2").add(user=u, host=other_host, command="/bin/df")


### PR DESCRIPTION
Update test_basic__hostname_hostname
Changes in the test framework for dyndns result in client hostname being changed according to enrolled backend.
We need to detect hostname instead of expecting client.test.
Added python-specific .gitignore file.
Fixed ci to work better in fork itself.

## Summary by Sourcery

Align hostname-based tests and CI configuration with the new dynamic hostname handling and fork-friendly setup.

Bug Fixes:
- Adapt hostname hostname test to use dynamic hostname detection via client hostname utilities instead of hard-coded hostnames.

CI:
- Update CI workflows to check out the current repository instead of a fixed upstream repository, improving fork compatibility.

Tests:
- Adjust hostname matching logic in test_basic__hostname_hostname to derive allowed and alternate hostnames from the client’s resolved FQDN and shortname utilities.

Chores:
- Add a Python-oriented .gitignore file to exclude common Python build and cache artifacts from version control.