### PR TITLE
Add missing descriptions to main.fmf test cases

### DIFF
--- a/Regression/bz1972820-use_pty-with-SELinux-ROLE/main.fmf
+++ b/Regression/bz1972820-use_pty-with-SELinux-ROLE/main.fmf
@@ -1,4 +1,8 @@
 summary: 'Defaults use_pty plus SELinux ROLE in user specification breaks terminal'
+description: |
+    Verify that enabling 'Defaults use_pty' together with an SELinux ROLE in the
+    user specification does not break terminal handling, checking for errors such
+    as 'cannot set terminal process group' or 'Inappropriate ioctl for device'.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Regression/bz497873-sudo-gives-bogus-group-membership-if-runas_default-is-used/main.fmf
+++ b/Regression/bz497873-sudo-gives-bogus-group-membership-if-runas_default-is-used/main.fmf
@@ -1,5 +1,8 @@
 summary: It tests sudo correctness of users' groups.
-description: ''
+description: |
+    Verify that sudo correctly resolves group membership when runas_default is
+    set, ensuring that running 'sudo id' does not report bogus group memberships
+    such as groups=0(root).
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 recommend:

--- a/Regression/bz500942-sudo-su-user-test/main.fmf
+++ b/Regression/bz500942-sudo-su-user-test/main.fmf
@@ -1,5 +1,7 @@
 summary: 'It tests desired behaviour: sudo su - user'
-description: ''
+description: |
+    Verify that 'sudo su - user' correctly switches to the target user when
+    sudoers rules allow 'su - [A-z]*' but deny 'su -' and 'su - root'.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 recommend:

--- a/Regression/bz512191-unable-to-use-globs-to-restrict-arguements/main.fmf
+++ b/Regression/bz512191-unable-to-use-globs-to-restrict-arguements/main.fmf
@@ -1,5 +1,8 @@
 summary: It tests wildcard restrictions.
-description: ''
+description: |
+    Verify that wildcard (glob) patterns in sudoers correctly restrict command
+    arguments, allowing access to files matching [A-z]* while denying access to
+    files starting with non-alphabetic characters.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 recommend:

--- a/Regression/symbolic-link-attack-in-SELinux-enabled-sudoedit/main.fmf
+++ b/Regression/symbolic-link-attack-in-SELinux-enabled-sudoedit/main.fmf
@@ -1,5 +1,8 @@
 summary: Race condition vulnerability in file handling of sudoedit SELinux RBAC support
-description: ''
+description: |
+    Verify that sudoedit with SELinux RBAC support is not vulnerable to a
+    symbolic link race condition attack, ensuring it does not segfault and does
+    not allow file ownership changes through a malicious EDITOR variable.
 contact: Martin Zelený <mzeleny@redhat.com>
 component:
 - sudo

--- a/Sanity/Timestamp-files/main.fmf
+++ b/Sanity/Timestamp-files/main.fmf
@@ -1,5 +1,8 @@
 summary: Check existence of new directories for timestamp files
-description: ''
+description: |
+    Verify that the expected directory for sudo timestamp files exists in one of
+    the standard locations (/var/db/sudo, /var/lib/sudo, /var/adm/sudo, or
+    /var/run/sudo/ts).
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 recommend:

--- a/Sanity/run-as/main.fmf
+++ b/Sanity/run-as/main.fmf
@@ -1,5 +1,9 @@
 summary: Test feature 'run as'. This means -u, -g options.
-description: ''
+description: |
+    Verify that sudo 'run as' functionality works correctly with -u and -g
+    options, including running as a default user, a specific user, a specific
+    group, and combined user and group specifications based on sudoers Runas_Spec
+    rules.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 require:

--- a/Sanity/sudo-python-plugin-examples/main.fmf
+++ b/Sanity/sudo-python-plugin-examples/main.fmf
@@ -1,5 +1,8 @@
 summary: Load the sudo python plugin examples provided in /usr/share/doc/sudo/examples
-description: ''
+description: |
+    Verify that sudo python plugin examples (approval, audit, conversation, I/O,
+    policy, and group plugins) from /usr/share/doc/sudo/examples load and
+    function correctly, including testing relative module paths.
 contact: Martin Zelený <mzeleny@redhat.com>
 component:
   - sudo

--- a/Sanity/sudoedit/main.fmf
+++ b/Sanity/sudoedit/main.fmf
@@ -1,4 +1,8 @@
 summary: This sanity test for sudoedit
+description: |
+    Verify that sudoedit works correctly in various configurations including
+    plain sudoedit, with SELinux role, SELinux type, and combined role and type
+    options, both with and without actual file modifications.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Sanity/sudoers-options-sanity-test/main.fmf
+++ b/Sanity/sudoers-options-sanity-test/main.fmf
@@ -1,6 +1,11 @@
 summary: This sanity test checks pre-defined (some are commented) options (examples)
     in sudoers file.
-description: ''
+description: |
+    Verify that the default sudoers file contains expected active options
+    (env_reset, secure_path, env_keep), commented examples (Host_Alias,
+    Cmnd_Alias, User_Alias), correct user/group settings, and that features like
+    requiretty, pam_service, iolog, env_check, and runas_check_shell behave as
+    configured.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 require:

--- a/Sanity/sudoers-sanity/main.fmf
+++ b/Sanity/sudoers-sanity/main.fmf
@@ -11,5 +11,9 @@ tier: '1'
 duration: 5m
 test: ./runtest.sh
 summary: A sudoers sanity test
+description: |
+    Verify that basic sudoers configuration works correctly, including that a
+    member of the wheel group can execute commands as root and that a user with
+    an explicit sudoers rule can run commands as root.
 extra-task: /CoreOS/sudo/Sanity/sudoers-sanity
 extra-nitrate: TC#0612869


### PR DESCRIPTION
Add descriptions to test cases that had empty or missing description field in main.fmf.

## Summary by Sourcery

Add missing descriptions to multiple fmf test case definitions to improve test metadata clarity.

Tests:
- Add descriptive metadata to regression test cases that previously had empty or missing descriptions.
- Add descriptive metadata to sanity test cases that previously had empty or missing descriptions.